### PR TITLE
Sanitize email address in articles page

### DIFF
--- a/content/articles.mdx
+++ b/content/articles.mdx
@@ -45,4 +45,4 @@ All were likely curated [here](https://news.ycombinator.com).
 - [**building a modern home (2021)** - Johnny Rodgers](https://johnnyrodgers.is/building-a-modern-home)
 
 If you have any recommendations on articles I should read, send them my
-way to [**trey@moen.ai**](mailto:trey@moen.ai).
+way to **trey at moen dot ai**.


### PR DESCRIPTION
## Summary
- Replace plain email address with obfuscated format "trey at moen dot ai" in the articles page
- Matches the sanitization pattern used in the homepage header
- Reduces exposure to spam bot harvesting

## Test plan
- [x] Verify email is displayed as "trey at moen dot ai" on the articles page
- [x] Confirm formatting is consistent with homepage header